### PR TITLE
hotfix to solve ValueError("Data must be 1-dimensional.") in boxcox

### DIFF
--- a/scipy/stats/morestats.py
+++ b/scipy/stats/morestats.py
@@ -1029,6 +1029,13 @@ def boxcox(x, lmbda=None, alpha=None):
     >>> plt.show()
 
     """
+    
+    ## hotfix to solve ValueError("Data must be 1-dimensional.") when only single value x (not array) is given with some value of lmbda
+    
+    if (lmbda is not None) and x > 0 and (type(x)==int or type(x)==float):  # single transformation if lambda value is given but for only single value x (not array)
+        return special.boxcox(x, lmbda)
+    ## end of fix
+    
     x = np.asarray(x)
     if x.ndim != 1:
         raise ValueError("Data must be 1-dimensional.")


### PR DESCRIPTION
Hotfix to solve ValueError("Data must be 1-dimensional.") when only single value x (not array) is given with some value of lmbda.
![image](https://user-images.githubusercontent.com/36568190/103298185-cb4a0700-4a1f-11eb-80bc-b9183cb39ffc.png)
<!-- 
Thanks for contributing a pull request! Please ensure that
your PR satisfies the checklist before submitting:
http://scipy.github.io/devdocs/dev/contributor/development_workflow.html#checklist-before-submitting-a-pr

Also, please name and describe your PR as you would write a
commit message:
https://docs.scipy.org/doc/numpy/dev/development_workflow.html#writing-the-commit-message

Note that we are a team of volunteers; we appreciate your
patience during the review process.

Again, thanks for contributing!
-->

#### Reference issue
<!--Example: Closes gh-WXYZ.-->

#### What does this implement/fix?
<!--Please explain your changes.-->

#### Additional information
<!--Any additional information you think is important.-->